### PR TITLE
create d/watch

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,5 @@
+version=4
+# GitHub hosted projects
+opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%lenmus-$1.tar.gz%" \
+   https://github.com/lenmus/lenmus/tags \
+   (?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate


### PR DESCRIPTION
This one isn't useful as-is, but will ease integration in the debian repo if someone want to pick it up. It is a file for the Debian infrastructure to automatically check if there is a new release.