### PR TITLE
Modifications and instructions for creating MacOS app bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,5 +168,4 @@ lomse/trunk/scripts/
 
 #Mac specific stuff:
 .DS_Store
-Info.plist.in
 

--- a/.gitignore
+++ b/.gitignore
@@ -166,4 +166,7 @@ lomse/trunk/scripts/
 #garbage from MS VisualStudio
 .vs/
 
+#Mac specific stuff:
+.DS_Store
+Info.plist.in
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -849,7 +849,7 @@ if(INSTALL_SOUNDFONT)
     set(LENMUS_SOUNDFONT_PATH "")   #to force to make it relative to <SHARED_DIR>
     if (NOT ("${FLUIDR3_PATH}" STREQUAL "${LENMUS_ROOT_DIR}/res/sounds/"))
         file(COPY ${FLUIDR3_PATH}/FluidR3_GM.sf2
-             DESTINATION ${LENMUS_ROOT_DIR}/res/sounds)
+             DESTINATION ${SHARED_DIR}/res/sounds)
     endif()
 endif()
 message(STATUS "LENMUS_SOUNDFONT_PATH=${LENMUS_SOUNDFONT_PATH}")
@@ -858,7 +858,7 @@ if(INSTALL_BRAVURA_FONT AND
    NOT ("${BRAVURA_FONT_PATH}" STREQUAL "${LENMUS_ROOT_DIR}/res/fonts/"))
         message(STATUS "BRAVURA_FONT_PATH=${BRAVURA_FONT_PATH}")
         file(COPY ${BRAVURA_FONT_PATH}/Bravura.otf
-             DESTINATION ${LENMUS_ROOT_DIR}/res/fonts)
+             DESTINATION ${SHARED_DIR}/res/fonts)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1537,7 +1537,7 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
 
 if (APPLE)
     # For Apple generate a drang & drop package
-    set(CPACK_GENERATOR "DRAGNDROP")
+    set(CPACK_GENERATOR "DragNDrop")
 
 elseif(UNIX AND NOT APPLE)
     # For Linux generate one or more Debian packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,11 +249,15 @@ OPTION(BUILD_PKG_BOUNDLE
     "Build package 'lenmus-ebooks': eBooks (all translations)"
     "OFF")
 
+if(NOT APPLE)
 set(MAN_INSTALL_DIR "/usr/share/man" 
     CACHE STRING "Directory for installing man pages")
+else()
+set(MAN_INSTALL_DIR "/usr/local/man"
+    CACHE STRING "Directory for installing man pages")
+endif()
 
-
-# Set a default build type if none was specified
+#Set a default build type if none was specified
 # https://stackoverflow.com/questions/24460486/cmake-build-type-is-not-being-used-in-cmakelists-txt
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Release' as none was specified.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,9 @@ if(MSVC)
 elseif(CMAKE_COMPILER_IS_GNUCC)
     set( LENMUS_COMPILER_MSVC "0")
     set( LENMUS_COMPILER_GCC "1")
+elseif(APPLE)    #???  set( LENMUS_COMPILER_MSVC "0") seems to be necessary.  Does  LENMUS_COMPILER_GCC  need to be defined?
+     set( LENMUS_COMPILER_MSVC "0")
+     set( LENMUS_COMPILER_GCC "0")
 endif()
 
 # build type
@@ -1306,7 +1309,7 @@ if (UNIX AND NOT APPLE)
     install(FILES ${LENMUS_ROOT_DIR}/res/other/org.lenmus.lenmus.appdata.xml
             DESTINATION "/usr/share/metainfo"
             COMPONENT main )
-endif(UNIX)
+endif(UNIX AND NOT APPLE)
 
 if(INSTALL_SOUNDFONT)
     install(FILES ${LENMUS_ROOT_DIR}/res/sounds/FluidR3_GM.sf2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,8 +181,8 @@ if(CMAKE_NO_STD_NAMESPACE)
 endif()
 
 # force to use c++11
-set(CMAKE_CXX_STANDARD 11)				#require c+11 or greater
-set(CMAKE_CXX_STANDARD_REQUIRED ON) 	#prevent fallback to any previous standard
+set(CMAKE_CXX_STANDARD 11)                #require c+11 or greater
+set(CMAKE_CXX_STANDARD_REQUIRED ON)     #prevent fallback to any previous standard
 
 #check that the compiler supports c++11 and std::regex
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -213,25 +213,25 @@ OPTION(LENMUS_USE_LOMSE_SOURCES
     "Build LenMus using Lomse sources instead of using the library"
     ON)
 OPTION(LENMUS_ENABLE_UNIT_TESTS
-	"Include also unit tests in LenMus executable"
-	ON)
+    "Include also unit tests in LenMus executable"
+    ON)
 OPTION(LENMUS_DOWNLOAD_SOUNDFONT
     "Download FluidR3 soundfont if not present in source tree"
-	OFF)
+    OFF)
 OPTION(LENMUS_DOWNLOAD_BRAVURA_FONT
     "Download Bravura.otf font if not present in source tree"
-	ON)
+    ON)
 OPTION(LENMUS_INSTALL_BRAVURA_FONT
     "Include Bravura music font in the package in the main and boundle packages"
-	ON)
+    ON)
 if(WIN32)
     OPTION(LENMUS_INSTALL_SOUNDFONT
         "Include FluidR3 soundfont in the package in the main and boundle packages"
-	    ON)
+        ON)
 else()
     OPTION(LENMUS_INSTALL_SOUNDFONT
         "Include FluidR3 soundfont in the package in the main and boundle packages"
-	    OFF)
+        OFF)
 endif()
 OPTION(BUILD_PKG_MAIN
     "Build package 'lenmus-main': Binaries and related files"
@@ -271,28 +271,28 @@ endif()
 #     + var: A variable that stores the result.
 #     + str: A string.
 MACRO(STRING_UNQUOTE var str)
-	set(_ret "${str}")
-	STRING(LENGTH "${str}" _strLen)
+    set(_ret "${str}")
+    STRING(LENGTH "${str}" _strLen)
 
-	# if _strLen > 1
-	#   if lCh and rCh are both "'"
-	#      Remove _lCh and _rCh
-	#   elseif lCh and rCh are both "\""
-	#      Remove _lCh and _rCh
-	# Otherwise don't touch
-	IF(_strLen GREATER 1)
-	    STRING(SUBSTRING "${str}" 0 1 _lCh)
-	    MATH(EXPR _strLen_1 ${_strLen}-1)
-	    MATH(EXPR _strLen_2 ${_strLen_1}-1)
-	    STRING(SUBSTRING "${str}" ${_strLen_1} 1 _rCh)
-	    #MESSAGE("_lCh=${_lCh} _rCh=${_rCh} _ret=|${_ret}|")
-	    IF("${_lCh}" STREQUAL "'" AND "${_rCh}" STREQUAL "'")
-		    STRING(SUBSTRING "${_ret}" 1 ${_strLen_2} _ret)
+    # if _strLen > 1
+    #   if lCh and rCh are both "'"
+    #      Remove _lCh and _rCh
+    #   elseif lCh and rCh are both "\""
+    #      Remove _lCh and _rCh
+    # Otherwise don't touch
+    IF(_strLen GREATER 1)
+        STRING(SUBSTRING "${str}" 0 1 _lCh)
+        MATH(EXPR _strLen_1 ${_strLen}-1)
+        MATH(EXPR _strLen_2 ${_strLen_1}-1)
+        STRING(SUBSTRING "${str}" ${_strLen_1} 1 _rCh)
+        #MESSAGE("_lCh=${_lCh} _rCh=${_rCh} _ret=|${_ret}|")
+        IF("${_lCh}" STREQUAL "'" AND "${_rCh}" STREQUAL "'")
+            STRING(SUBSTRING "${_ret}" 1 ${_strLen_2} _ret)
         ELSEIF ("${_lCh}" STREQUAL "\"" AND "${_rCh}" STREQUAL "\"")
-		    STRING(SUBSTRING "${_ret}" 1 ${_strLen_2} _ret)
-	    ENDIF()
-	ENDIF()
-	set(${var} "${_ret}")
+            STRING(SUBSTRING "${_ret}" 1 ${_strLen_2} _ret)
+        ENDIF()
+    ENDIF()
+    set(${var} "${_ret}")
 ENDMACRO()
 
 
@@ -314,9 +314,13 @@ if(WIN32)
     set( LENMUS_PLATFORM_WIN32 "1")
     set( LENMUS_PLATFORM_UNIX "0")
     set( LENMUS_PLATFORM_MAC "0")
-elseif(UNIX)
+elseif(UNIX AND NOT APPLE)
     set( LENMUS_PLATFORM_WIN32 "0")
     set( LENMUS_PLATFORM_UNIX "1")
+    set( LENMUS_PLATFORM_MAC "0")
+elseif(APPLE)
+    set( LENMUS_PLATFORM_WIN32 "0")
+    set( LENMUS_PLATFORM_UNIX "1")  #for now keep this. When all other issued solved we will fix this and check
     set( LENMUS_PLATFORM_MAC "0")
 endif()
 
@@ -390,13 +394,15 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
 endif()
 message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}" )
 set(ROOT_INSTALL ${CMAKE_INSTALL_PREFIX} )
-set(LENMUS_INSTALL_ROOT "${ROOT_INSTALL}/" )	#LENMUS_INSTALL_ROOT is needed for lenmus_config.h
+set(LENMUS_INSTALL_ROOT "${ROOT_INSTALL}/" )    #LENMUS_INSTALL_ROOT is needed for lenmus_config.h
 
 
 #set shared folder
-if( UNIX )
-	set(SHARED_DIR ${ROOT_INSTALL}/share/${CMAKE_PROJECT_NAME}/${LENMUS_PACKAGE_VERSION} )
-elseif( WIN32 )
+if(UNIX AND NOT APPLE)
+    set(SHARED_DIR ${ROOT_INSTALL}/share/${CMAKE_PROJECT_NAME}/${LENMUS_PACKAGE_VERSION} )
+elseif(APPLE)
+    set(SHARED_DIR ${ROOT_INSTALL}/Resources )
+elseif(WIN32)
     set(SHARED_DIR ${ROOT_INSTALL} )
 endif()
 
@@ -418,6 +424,9 @@ include_directories(
 #------------------------------------------------------------------------
 if( WIN32 )
     #only boundle package is possible
+    set(BUILD_PKG_BOUNDLE 1)
+elseif( APPLE )
+    #force to build the boundle package
     set(BUILD_PKG_BOUNDLE 1)
 elseif( UNIX )
     if((NOT BUILD_PKG_BOUNDLE)
@@ -560,20 +569,20 @@ if (LENMUS_ENABLE_UNIT_TESTS)
     else(UNITTEST++_FOUND)
         message(STATUS "UnitTest++ not found. Unit tests disabled.")
         message(STATUS "UnitTest++_DIR = $ENV{UnitTest++_DIR}")
-		set(LENMUS_ENABLE_UNIT_TESTS OFF)
+        set(LENMUS_ENABLE_UNIT_TESTS OFF)
     endif()
 endif(LENMUS_ENABLE_UNIT_TESTS)
 
 
 #change value to "1" or "0", as required in lenmus_config.h
 if (LENMUS_ENABLE_UNIT_TESTS)
-	set(LENMUS_ENABLE_UNIT_TESTS "1")
+    set(LENMUS_ENABLE_UNIT_TESTS "1")
 else()
-	set(LENMUS_ENABLE_UNIT_TESTS "0")
-endif()	
+    set(LENMUS_ENABLE_UNIT_TESTS "0")
+endif()    
 if(WIN32)
     #TODO: I have problems to link with UnitTest++, so disable it for now
-	set(LENMUS_ENABLE_UNIT_TESTS "0")
+    set(LENMUS_ENABLE_UNIT_TESTS "0")
 endif()
 message(STATUS "LENMUS_ENABLE_UNIT_TESTS = " ${LENMUS_ENABLE_UNIT_TESTS} )
 
@@ -582,11 +591,11 @@ message(STATUS "LENMUS_ENABLE_UNIT_TESTS = " ${LENMUS_ENABLE_UNIT_TESTS} )
 if(WIN32)
     #See: https://stackoverflow.com/questions/41574177/cmake-findwxwidgets-fails-only-on-first-invocation-of-configure-command
     set(WX_ROOT_DIR "$ENV{wxWidgets_DIR}")
-	if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-		set(wxWidgets_CONFIGURATION mswud)
-	else()
-		set(wxWidgets_CONFIGURATION mswu)
-	endif()
+    if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+        set(wxWidgets_CONFIGURATION mswud)
+    else()
+        set(wxWidgets_CONFIGURATION mswu)
+    endif()
     set(wxWidgets_ROOT_DIR "$ENV{wxWidgets_DIR}")
     set(wxWidgets_LIB_DIR "$ENV{wxWidgets_DIR}/lib/vc_x64_lib")
 endif(WIN32)
@@ -724,7 +733,7 @@ endif(PNG_FOUND)
 
 
 # Check for fontconfig: required by Lomse
-if (UNIX)
+if (UNIX)   #includes APPLE
     find_path(FONTCONFIG_INCLUDE_DIR fontconfig/fontconfig.h)
     find_library(FONTCONFIG_LIBRARIES NAMES fontconfig libfontconfig)
     if (("${FONTCONFIG_INCLUDE_DIR}" STREQUAL "FONTCONFIG_INCLUDE_DIR-NOTFOUND")
@@ -786,6 +795,15 @@ if(WIN32)
     set(TEMPLATES_DIR .)
     set(XRC_DIR .)
     set(DOCS_DIR .)
+elseif(APPLE)
+    set(BIN_DIR "${ROOT_INSTALL}/Contents/MacOS")
+    set(SAMPLES_DIR $ENV{HOME}/${CMAKE_PROJECT_NAME} )
+    set(LOCALE_DIR ${SHARED_DIR})
+    set(LOCALE_LICENSES_DIR ${SHARED_DIR})
+    set(RES_DIR "${SHARED_DIR}/res")
+    set(TEMPLATES_DIR ${SHARED_DIR})
+    set(XRC_DIR ${SHARED_DIR})
+    set(DOCS_DIR ${SHARED_DIR})
 else()
     set(BIN_DIR "${ROOT_INSTALL}/bin")
     set(SAMPLES_DIR $ENV{HOME}/${CMAKE_PROJECT_NAME} )
@@ -871,7 +889,7 @@ endif()
 
 
 # create and include the man page
-if (UNIX)
+if (UNIX)   #includes APPLE
     include( ${LENMUS_ROOT_DIR}/manpage.cmake )
 endif()
 
@@ -887,12 +905,12 @@ configure_file(
 # Target: LenMus program
 #////////////////////////////////////////////////////////////////////////
 
-set (LENMUS  lenmus)
+set (LENMUS_APP  lenmus)
 
 # set name of lenmus executable
 if( WIN32 )
     set( CMAKE_EXECUTABLE_SUFFIX ".exe" )
-elseif( UNIX )
+elseif( UNIX )   #includes APPLE
     set( CMAKE_EXECUTABLE_SUFFIX "" )
 endif()
 
@@ -1116,12 +1134,14 @@ endif()
 
 
 # Define target
-if(UNIX)
-	add_executable( ${LENMUS} ${ALL_SOURCES} )
+if (UNIX AND NOT APPLE)
+    add_executable( ${LENMUS_APP} ${ALL_SOURCES} )
+elseif (APPLE)
+    add_executable( ${LENMUS_APP} MACOSX_BUNDLE ${ALL_SOURCES} )
 else()
-	add_executable( ${LENMUS} WIN32 ${ALL_SOURCES} )
+    add_executable( ${LENMUS_APP} WIN32 ${ALL_SOURCES} )
 endif()
-add_dependencies(${LENMUS} lenmus-version)
+add_dependencies(${LENMUS_APP} lenmus-version)
 
 
 # Add resources
@@ -1136,70 +1156,80 @@ add_dependencies(${LENMUS} lenmus-version)
 #endif()
 
 
-# Compiler options
+# Compiler options and definitions
 if (WIN32)
     # remove noisy warning 4996: function or variable may be unsafe (i.e. strcat)
-    set_target_properties(${LENMUS} PROPERTIES COMPILE_FLAGS "/wd4996")
-endif(WIN32)
+    set_target_properties(${LENMUS_APP} PROPERTIES COMPILE_FLAGS "/wd4996")
 
-# "Print all warnings", macros for GCC & __UNIX__
-if(UNIX)
+    # force to use static Runtime library
+    set(CompilerFlags
+            CMAKE_CXX_FLAGS
+            CMAKE_CXX_FLAGS_DEBUG
+            CMAKE_CXX_FLAGS_RELEASE
+            CMAKE_C_FLAGS
+            CMAKE_C_FLAGS_DEBUG
+            CMAKE_C_FLAGS_RELEASE
+        )
+    foreach(CompilerFlag ${CompilerFlags})
+        string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+    endforeach()
+
+elseif(UNIX AND NOT APPLE)
+    # "Print all warnings", macros for GCC & __UNIX__
     add_definitions( -Wall -DGCC -D__UNIX__ )
-endif(UNIX)
 
+elseif(APPLE)
+    # "Print all warnings", macros for __UNIX__
+    add_definitions( -Wall -D__UNIX__ )
 
-# Linker options
-#if(WIN32)
-	#if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-		#set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS /ENTRY:WinMainCRTStartup")
-		#link_libraries(libucrtd.lib)
-	#else()
-		#set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS /ENTRY:WinMainCRTStartup")
-		#link_libraries(libucrt.lib)
-	#endif()
-#endif(WIN32)
+endif()
 
 
 # libraries to link
-target_link_libraries ( ${LENMUS} 
+target_link_libraries ( ${LENMUS_APP} 
             ${wxWidgets_LIBRARIES} ${PortMidi_LIBRARIES} ${PortTime_LIBRARIES}
             ${LOMSE_LIBRARIES} ${SQLite3_LIBRARIES} ${UNITTEST_LIBRARIES} 
-			${FREETYPE_LIBRARIES} ${PNG_LIBRARIES} 
-			${ZLIB_LIBRARIES} ${FONTCONFIG_LIBRARY}
+            ${FREETYPE_LIBRARIES} ${PNG_LIBRARIES} 
+            ${ZLIB_LIBRARIES} ${FONTCONFIG_LIBRARY}
 )
 
 
-# Target properties
-#if(APPLE)
-#    set_target_properties(${PROJECT_NAME} PROPERTIES
-#        RESOURCE ${RESOURCES_DIR}/other/osx/carbon/wxmac.icns
-#        MACOSX_BUNDLE_ICON_FILE wxmac.icns
-#        MACOSX_BUNDLE_COPYRIGHT "Copyright LenMus"
-#        MACOSX_BUNDLE_GUI_IDENTIFIER "org.wxwidgets.minimal"
-#        )
-#endif()
+# Target properties for macOS bundle
+if(APPLE)
+    set_target_properties(${LENMUS_APP} PROPERTIES
+           MACOSX_BUNDLE_EXECUTABLE_NAME ${LENMUS_APP}
+        MACOSX_BUNDLE_GUI_IDENTIFIER "org.lenmus.lenmus"
+        MACOSX_BUNDLE_BUNDLE_NAME "LenMus Phonascus"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING ${LENMUS_VERSION}
+        MACOSX_BUNDLE_LONG_VERSION_STRING ${LENMUS_VERSION_LONG}
+        MACOSX_BUNDLE_COPYRIGHT "© 2002-2020 LenMus project. License GNU GPL v.3 or greater"
+        MACOSX_BUNDLE_INFO_PLIST "${LENMUS_ROOT_DIR}/Info.plist.in"
+        MACOSX_BUNDLE_BUNDLE_VERSION 1
+    )
 
-if (WIN32)
-	# In Windows force to use static Runtime library
-	set(CompilerFlags
-			CMAKE_CXX_FLAGS
-			CMAKE_CXX_FLAGS_DEBUG
-			CMAKE_CXX_FLAGS_RELEASE
-			CMAKE_C_FLAGS
-			CMAKE_C_FLAGS_DEBUG
-			CMAKE_C_FLAGS_RELEASE
-		)
-	foreach(CompilerFlag ${CompilerFlags})
-		string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
-	endforeach()
-endif(WIN32)
+        # ADD_LANG
+    set(BUNDLE_LOCALIZATIONS
+"       <string>de</string>
+        <string>el</string>
+        <string>en</string>
+        <string>es</string>
+        <string>eu</string>
+        <string>fr</string>
+        <string>gl_ES</string>
+        <string>it</string>
+        <string>nl</string>
+        <string>tr</string>
+        <string>zh_CN</string>
+")
+endif()
+
 
 # Display compiler and linker settings
-message("Configuration for target ${LENMUS}")
+message("Configuration for target ${LENMUS_APP}")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-	message(STATUS "Compiler flags: ${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS_DEBUG}")
+    message(STATUS "Compiler flags: ${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS_DEBUG}")
 else()
-	message(STATUS "Compiler flags: ${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS_RELEASE}")
+    message(STATUS "Compiler flags: ${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS_RELEASE}")
 endif()
 message(STATUS "Linker flags: ${CMAKE_EXE_LINKER_FLAGS}" )
 
@@ -1215,10 +1245,9 @@ endif(BUILD_PROGRAM)
 # ------------------------------------------------------------------------------
 
 # bin. LenMus program and other binary and related files (BIN_DIR)
-install(TARGETS ${LENMUS}
-	    RUNTIME
-        DESTINATION ${BIN_DIR}
-        COMPONENT main
+install(TARGETS ${LENMUS_APP}
+    RUNTIME DESTINATION ${BIN_DIR} COMPONENT main
+    BUNDLE DESTINATION . COMPONENT main
 )
 
 if(WIN32)
@@ -1263,7 +1292,7 @@ install(FILES ${LENMUS_ROOT_DIR}/docs/html/LICENSE_GNU_FDL_1.3.txt
 install(FILES ${LENMUS_ROOT_DIR}/installer/msw/locale/license_en.txt
         DESTINATION ${DOCS_DIR} COMPONENT main )
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
     # Install desktop entry
     install(FILES ${LENMUS_ROOT_DIR}/res/desktop/org.lenmus.lenmus.desktop
             DESTINATION "/usr/share/applications"
@@ -1290,6 +1319,7 @@ if(INSTALL_BRAVURA_FONT)
             DESTINATION ${RES_DIR}/fonts
             COMPONENT main )
 endif()
+
 
 
 # Package: lenmus-i18n
@@ -1319,31 +1349,31 @@ install(FILES ${LENMUS_ROOT_DIR}/installer/msw/locale/license_zh_CN.txt
 
 # locale folder. help files and language catalogs for all languages
 install(DIRECTORY  ${LENMUS_ROOT_DIR}/locale
-		DESTINATION ${LOCALE_DIR}
+        DESTINATION ${LOCALE_DIR}
         COMPONENT i18n 
         FILES_MATCHING
-		    PATTERN "common/*.*"
-		    PATTERN "*.htm"
-		    #help
+            PATTERN "common/*.*"
+            PATTERN "*.htm"
+            #help
             PATTERN "help*" EXCLUDE
             PATTERN "images*" EXCLUDE
-		    #PATTERN "*.html"
-		    #PATTERN "*.js"
-		    #PATTERN "*.map"
-		    #PATTERN "*.inv"
-		    #PATTERN "*.png"
-		    #PATTERN "*.gif"
-		    #PATTERN "*.jpg"
-		    #PATTERN "*.css"
-		    #language catalogs
-		    PATTERN "*.mo"
-		    PATTERN "x_*" EXCLUDE
-		    PATTERN "z_*" EXCLUDE
-		    PATTERN "*~" EXCLUDE
-		    #exclude unsupported languages
-		        # ADD_LANG
-		    PATTERN "kk*" EXCLUDE
-		    PATTERN "ru*" EXCLUDE
+            #PATTERN "*.html"
+            #PATTERN "*.js"
+            #PATTERN "*.map"
+            #PATTERN "*.inv"
+            #PATTERN "*.png"
+            #PATTERN "*.gif"
+            #PATTERN "*.jpg"
+            #PATTERN "*.css"
+            #language catalogs
+            PATTERN "*.mo"
+            PATTERN "x_*" EXCLUDE
+            PATTERN "z_*" EXCLUDE
+            PATTERN "*~" EXCLUDE
+            #exclude unsupported languages
+                # ADD_LANG
+            PATTERN "kk*" EXCLUDE
+            PATTERN "ru*" EXCLUDE
 )
 
 #generate include files with translations for NSIS installer 
@@ -1395,17 +1425,17 @@ endif()
 
 # locale folder. eBooks for all languages (English included)
 install(DIRECTORY  ${LENMUS_ROOT_DIR}/locale/
-		DESTINATION ${LOCALE_DIR}/locale
+        DESTINATION ${LOCALE_DIR}/locale
         COMPONENT ebooks
         FILES_MATCHING
-		    #books 
-		    PATTERN "*.lmb"
-		    #exclude unsupported languages
-		        # ADD_LANG
-		    PATTERN "x_*" EXCLUDE
-		    PATTERN "z_*" EXCLUDE
-		    PATTERN "kk*" EXCLUDE
-		    PATTERN "ru*" EXCLUDE
+            #books 
+            PATTERN "*.lmb"
+            #exclude unsupported languages
+                # ADD_LANG
+            PATTERN "x_*" EXCLUDE
+            PATTERN "z_*" EXCLUDE
+            PATTERN "kk*" EXCLUDE
+            PATTERN "ru*" EXCLUDE
 )
 
 
@@ -1435,10 +1465,24 @@ install(DIRECTORY ${LENMUS_ROOT_DIR}/res/sounds   DESTINATION ${RES_DIR}
 
 # samples 
 #install(DIRECTORY ${LENMUS_ROOT_DIR}/scores/samples  DESTINATION "${SAMPLES_DIR}"
-#	    FILES_MATCHING PATTERN "*.lms"
-#	    PATTERN "test_set" EXCLUDE
+#        FILES_MATCHING PATTERN "*.lms"
+#        PATTERN "test_set" EXCLUDE
 #       COMPONENT common )
 #)
+
+
+# fix up the macOS bundle in-place and make it standalone
+if (APPLE)
+    # add Mac specific extension .app
+    set(APPS "\${CMAKE_INSTALL_PREFIX}/${LENMUS_APP}.app")
+
+    # Directories to look for dependencies
+    set(DIRS ${CMAKE_BINARY_DIR})
+
+    install(CODE "include(BundleUtilities)
+        fixup_bundle(\"${APPS}\" \"\" \"${DIRS}\")")
+endif()
+
 
 
 
@@ -1488,14 +1532,16 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
  commercial purposes.
 ")
 
-if(UNIX)
-    #-------------------------------------------------------------------------------------
-	# configure CPack for Debian packages
-    #-------------------------------------------------------------------------------------
-	set(CPACK_GENERATOR "DEB")
-	set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Cecilio Salmeron <s.cecilio@gmail.com>")
+if (APPLE)
+    # For Apple generate a drang & drop package
+    set(CPACK_GENERATOR "DRAGNDROP")
+
+elseif(UNIX AND NOT APPLE)
+    # For Linux generate one or more Debian packages
+    set(CPACK_GENERATOR "DEB")
+    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Cecilio Salmeron <s.cecilio@gmail.com>")
     set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${LENMUS_VENDOR_SITE}")
-    set(CPACK_STRIP_FILES ON)		#remove debug information, if any, from binaries
+    set(CPACK_STRIP_FILES ON)        #remove debug information, if any, from binaries
 
     #auxiliary variable describing current available translations
         # ADD_LANG
@@ -1521,9 +1567,9 @@ if(UNIX)
     string(CONCAT CPACK_PACKAGE_FILE_NAME "${CPACK_DEBIAN_PACKAGE_NAME}"
             "_${LENMUS_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
     if (LENMUS_USE_LOMSE_SOURCES)
-	    set(CPACK_DEBIAN_PACKAGE_DEPENDS "")
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "")
     else()
-	    set(CPACK_DEBIAN_PACKAGE_DEPENDS "liblomse (>= 0.25), ")
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "liblomse (>= 0.25), ")
     endif()
     string(APPEND CPACK_DEBIAN_PACKAGE_DEPENDS
         "libsqlite3-0, libportmidi0, fluid-soundfont-gm, "
@@ -1619,15 +1665,11 @@ ${LENMUS_AVAILABLE_LOCALE}"
 ${LENMUS_AVAILABLE_LOCALE}"
 )
 
-
-
 elseif(WIN32)
-    #-------------------------------------------------------------------------------------
-    # configure CPack for NSIS installer
-    #-------------------------------------------------------------------------------------
+    # For Windows generate a NSIS installer
     # AWARE: Only variables starting with "CPACK_" can be used to customize the installer.
     set(CPACK_GENERATOR "NSIS")
-    set(CPACK_STRIP_FILES ON)		#remove debug information, if any, from binaries
+    set(CPACK_STRIP_FILES ON)        #remove debug information, if any, from binaries
     set(CPACK_PACKAGE_NAME "lenmus")
     set(CPACK_PACKAGE_VERSION ${LENMUS_PACKAGE_VERSION})
     
@@ -1639,8 +1681,9 @@ elseif(WIN32)
     set(CPACK_LENMUS_BUILD_INSTALLER_PATH "${CMAKE_BINARY_DIR}")
     set(CPACK_LENMUS_INSTALL_PATH "${SHARED_DIR}")
 
-	message("Package name: ${CPACK_PACKAGE_FILE_NAME}" )
-	message("Installation default path: ${CPACK_LENMUS_INSTALL_PATH}" )
+    message("Package name: ${CPACK_PACKAGE_FILE_NAME}" )
+    message("Installation default path: ${CPACK_LENMUS_INSTALL_PATH}" )
+
 endif()
 
 # Must be after the last CPACK macro

--- a/Info.plist.in
+++ b/Info.plist.in
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+    <key>CFBundleLocalizations</key>
+    <array>
+        ${BUNDLE_LOCALIZATIONS}
+    </array>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>

--- a/cmake-modules/FindZLib.cmake
+++ b/cmake-modules/FindZLib.cmake
@@ -27,6 +27,7 @@ find_path(ZLIB_INCLUDE_DIR
 find_library(ZLIB_LIBRARY
     NAMES
         zlib
+	z
     PATHS
         /usr/lib/
         /usr/local/lib

--- a/docs/building/macOS_build_instructions.txt
+++ b/docs/building/macOS_build_instructions.txt
@@ -1,0 +1,185 @@
+Building LenMus on MacOS
+========================
+
+Last updated:  20/June/2020
+
+Table of contents
+-----------------
+
+1.  Current state of development and general requirements
+
+2.  Installing requirements and dependencies
+    2.1  Xcode
+    2.2  Homebrew
+    2.3  Libraries and utilities
+    2.4  wxWidgets
+    2.5  FluidR3_GM.sf2
+
+3.  Command-line install
+    3.1  Building
+    3.2  Preparing the app bundle
+    3.3  Testing the app bundle
+    3.4  Final fix and install
+
+4.  (optional) Xcode IDE development
+
+============================================================
+1. Current state of development and general requirements
+============================================================
+
+
+These instructions are tested on a Mac running Catalina (MacOS 10.15) and Xcode version 11.5.  They will probably work on some earlier versions (an earlier version has been successfully built under MacOS 10.14 -- Mojave).  
+
+At present LenMus is mostly functional under MacOS.  There is at least one lesson that LenMus always crashes on, and a minor issue with the metronome interface that can be worked around.  Hopefully these will be fixed soon.
+
+
+============================================================
+2. Installing requirements and dependencies
+============================================================
+
+2.1  Xcode
+-----------
+
+Xcode is a free download from the App store, and contains the basic software development tools (C++ compiler, make, etc.) needed.  It includes both command-line tools and a very sophisticated IDE.  This needs to be installed first.
+
+2.1  Homebrew
+-------------
+
+Install the Homebrew package manager.  This will allow easy installation of various libraries needed by LenMus.  See https://brew.sh/, or just open a terminal window and paste in:
+
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
+It should be possible (and is recommended) to install Homebrew as a regular user with administrative privileges (NOT using sudo.)  You can find discussion of this on the web if you run into problems.
+
+
+
+2.2 Libraries and utilities
+---------------------------
+
+LenMus requires the cmake utility, as well as some additional libraries.  In a terminal window, use the Homebrew commands:
+
+    brew install cmake
+    brew install portmidi
+    brew install fluid-synth
+    brew install fontconfig
+
+LenMus also requires sqlite3, libpng, zlib, and FreeType2.  These should already be available on your Mac, but in case of problems you may wish to look for Homebrew alternatives.
+
+
+2.3 wxWidgets
+-------------
+
+There is a Homebrew implementation of wxWidgets, although not the most current version.  I had some difficulties with the Homebrew version, but you may wish to try it, using:
+
+   brew install wxwidgets
+
+This would install a 3.0.x version. The most current version is 3.1.x.  If you encounter problems using LenMus with this version, I recommend doing:
+
+   brew uninstall wxwidgets
+
+and installing the latest version (3.1.x) from source.  Go to
+
+   http://wxwidgets.org/downloads/
+
+and select the source for Linux, MacOS, etc.  There will be build instructions in the source.  Do a "make install" after building to install these libraries in /usr/local.
+
+
+2.5  FluidR3_GM.sf2
+-------------------
+
+The sound font FluidR3_GM.sf2 required by the internal synthesizer can be downloaded from 
+
+   https://github.com/lenmus/lenmus/releases/download/Release_5.5.0/FluidR3_GM.sf2
+
+It should be placed in the res/sounds folder of the LenMus source tree.
+
+
+
+============================================================
+3. Command-line Install
+============================================================
+
+(Alternatively, LenMus can be built using the Xcode IDE.  See section 4 below.)
+
+
+3.1  Building
+-------------
+
+Assuming you're in the top-level lenmus source folder, issue the commands:
+
+     mkdir z_mybuild
+     cd z_mybuild
+     cmake ../
+
+If no errors from the "cmake" command, issue:
+
+     make
+
+There will be lots of warnings from the make command, but hopefully no errors.
+
+
+
+3.2  Preparing the app bundle
+-----------------------------
+
+(This part should be automated in a future release.)  If there are no errors from the "make" command, inside your z_mybuild folder there should be a folder "bin" containing a folder hierarchy 
+
+     bin --  lenmus.app -- Contents
+
+Inside the folder "Contents" will be a file "Info.plist" and a folder MacOS containing the binary executable "lenmus".  We need to add some support files.  So, starting from the "z_mybuild" folder, issue the commands:
+
+     cd bin/lenmus.app/Contents
+     mkdir -p Resources
+     cp -r  ../../../../locale ./Resources/
+     cp -r  ../../../../res ./Resources/
+     cp -r  ../../../../templates ./Resources/
+     cp -r  ../../../../xrc ./Resources/
+
+For a complete distribution, also copy from the top lenmus folder the files AUTHORS, CHANGELOG.md, INSTALL, all the various license files (LICENSE, LICENSE_GNU_FDL_1.3.txt, LICENSE_GNU_GPL_1.3.txt, license_*.txt), NEWS, README.md, and THANKS.  The app will run without these but they should be included for completeness, especially if app is distributed.
+
+
+
+
+
+3.3  Testing the app bundle
+---------------------------
+
+Go back to the "z_mybuild/bin" folder containing "lenmus.app".  (E.g., cd ../.. from the previous step.)  Test things out by issuing the command:
+
+    open ./lenmus.app
+
+A functional version of lenmus should now open.  Test it out and exit it when finished testing.
+
+
+
+3.4  Final fix and install
+--------------------------
+
+If the test works, go back to the z_mybuild folder  (cd .. from the previous step) and issue the command 
+
+   make package
+
+This should build an installation package with a name like "lenmus-x.x.x-Darwin.dmg" in the "z_mybuild" folder.  Double-click on it in the Finder to open it.  You can move the app to the /Applications folder, your desktop, or any other folder of your choice.
+
+TROUBLESHOOTING:  "make package" may fail.  As part of the package-building process, the shared libraries required by LenMus are copied into a FrameWorks folder in the app bundle and edited with the standard utility "install_name_tool" to change their install paths.  For this to work, the libraries must have been built with write permission for the owner (mode 0644).  Some Homebrew packages have their libraries' permissions incorrectly set to mode 0444.  To fix this:
+
+    cd /usr/local/Cellar
+    find . -type f -name \*.dylib | xargs chmod u+w
+
+and try "make package" again from the z_build folder.
+
+
+
+
+============================================================
+4.  (optional) Xcode IDE development
+============================================================
+
+In step 3.1, use instead
+
+    mkdir z_mybuild
+    cd z_mybuild
+    cmake -G Xcode ../
+
+This will generate an Xcode project file in the z_mybuild folder allowing one to continue using the Xcode IDE.  This would be preferred for development and debugging, or just exploring the source code.  If you do this, after opening the project I suggest opening File--Project Settings, and changing the Build system to "New Build System".  This will enable debugging.  There will be some obvious Xcode targets corresponding to "make" and "make package".  The manual intervention in step 3.2 is still needed, and you may find the lenmus.app folder buried one level deeper in the bin folder.  Make the obvious changes.
+

--- a/src/app/lenmus_app.cpp
+++ b/src/app/lenmus_app.cpp
@@ -78,6 +78,11 @@ using namespace std;
     #define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
 #endif
 
+//For finding executable path on MacOS:
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
 
 // This macro will allow wxWindows to create the application object during program
 // execution (it's better than using a static object for many reasons) and also
@@ -302,6 +307,17 @@ wxString TheApp::determine_exec_path()
             return wxPathOnly(wxString(execPathName));
 
     #endif // __linux__ && !__ANDROID__
+    
+    //A method for MacOS:
+    #if __APPLE__
+         char macPathName[PATH_MAX];
+         uint32_t execSize = sizeof(macPathName);
+         if(_NSGetExecutablePath(macPathName, &execSize ) == 0){
+            if(realpath(macPathName, execPathName)){
+                return wxPathOnly(wxString(execPathName));
+            }
+         }
+    #endif // macOS
 
 #endif
 

--- a/src/app/lenmus_app.cpp
+++ b/src/app/lenmus_app.cpp
@@ -990,9 +990,9 @@ SplashFrame* TheApp::create_GUI(int nMilliseconds, bool fFirstTime)
         wxSafeYield();
     }
 
-#ifndef __WXMAC__
+//#ifndef __WXMAC__
     m_frame->Show(true);
-#endif //ndef __WXMAC__
+//#endif //ndef __WXMAC__
     SetTopWindow(m_frame);
 
     return pSplash;

--- a/src/app/lenmus_app.cpp
+++ b/src/app/lenmus_app.cpp
@@ -309,7 +309,7 @@ wxString TheApp::determine_exec_path()
     #endif // __linux__ && !__ANDROID__
     
     //A method for MacOS:
-    #if __APPLE__
+    #ifdef __APPLE__
          char macPathName[PATH_MAX];
          uint32_t execSize = sizeof(macPathName);
          if(_NSGetExecutablePath(macPathName, &execSize ) == 0){

--- a/src/app/lenmus_main_frame.cpp
+++ b/src/app/lenmus_main_frame.cpp
@@ -80,7 +80,7 @@ using namespace lomse;
 #include <wx/filename.h>
 
 #ifdef __WXMAC__
-#include <wx/mac/printdlg.h>
+#include <wx/osx/printdlg.h>
 #endif
 
 

--- a/src/dialogs/lenmus_dlg_metronome.cpp
+++ b/src/dialogs/lenmus_dlg_metronome.cpp
@@ -185,7 +185,7 @@ void DlgMetronome::create_dialog()
 	bSizer1->Add( 0, 0, 0, wxRIGHT|wxLEFT, 10 );
 
 	m_pItalianTempo = new wxChoice( this, k_id_choice_italian_tempo, wxDefaultPosition, wxDefaultSize, m_italianTempoChoices, 0 );
-	m_pItalianTempo->SetSelection( 0 );
+//	m_pItalianTempo->SetSelection( 0 );
 	bSizer1->Add( m_pItalianTempo, 1, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
 
@@ -323,7 +323,7 @@ void DlgMetronome::create_dialog()
     m_beatNoteChoice = new wxBitmapComboBox( this, k_id_metronome_note,
                              wxEmptyString, wxDefaultPosition, wxSize(60, -1),
                              0, nullptr, wxCB_READONLY);
-	m_beatNoteChoice->SetSelection( 0 );
+//	m_beatNoteChoice->SetSelection( 0 );
 	bSizer161->Add( m_beatNoteChoice, 0, wxALL, 5 );
 
 	sbSizer1->Add( bSizer161, 0, 0, 5 );

--- a/src/globals/lenmus_paths.cpp
+++ b/src/globals/lenmus_paths.cpp
@@ -201,17 +201,34 @@ void Paths::initialize()
     wxFileName oSoundFonts(m_sPrefix);
     oSoundFonts.AppendDir("res");
     oSoundFonts.AppendDir("sounds");
+    
+
 
 #elif (LENMUS_PLATFORM_UNIX == 1)
     //Base paths for Linux Release version
     //---------------------------------------
 
     //2. Non-modificable data, shared among all users on the computer (SHARED_DIR)
-    //      /usr/local/share/lenmus/x.x.x/
+    //      /usr/local/share/lenmus/x.x.x/ (unless on a Mac).
+#if __APPLE__
+    //On a Mac, if bundling LenMus in an app, SHARED_DIR should be
+    // <app-location>/lenmus.app/Contents/Resources/x.x.x/
+    //where <app-location> is the directory the app is installed in (usually "/Applications", but it
+    // could be anywhere.)
+    // Since the binary is installed in <app-location>/lenmus.app/Contents/MacOS, we can assume
+    // that m_sPrefix contains "<app-location>/lenmus.app/Contents" at this point.
+    wxFileName oSharedHome(m_sPrefix);
+    oSharedHome.AppendDir("Resources");
+    oSharedHome.AppendDir(sVersion);
+#else
+    // this is for Linux:
     wxFileName oSharedHome(m_sPrefix);
     oSharedHome.AppendDir("share");
     oSharedHome.AppendDir("lenmus");
     oSharedHome.AppendDir(sVersion);
+#endif
+    
+    //Remaining configuration should be the same for Linux or Mac.
 
     //3. Configuration files, user & version dependent (CONFIG_DIR)
     //      ~/.config/lenmus/x.x.x/

--- a/src/globals/lenmus_paths.cpp
+++ b/src/globals/lenmus_paths.cpp
@@ -212,14 +212,13 @@ void Paths::initialize()
     //      /usr/local/share/lenmus/x.x.x/ (unless on a Mac).
 #if __APPLE__
     //On a Mac, if bundling LenMus in an app, SHARED_DIR should be
-    // <app-location>/lenmus.app/Contents/Resources/x.x.x/
+    // <app-location>/lenmus.app/Contents/Resources/
     //where <app-location> is the directory the app is installed in (usually "/Applications", but it
     // could be anywhere.)
     // Since the binary is installed in <app-location>/lenmus.app/Contents/MacOS, we can assume
     // that m_sPrefix contains "<app-location>/lenmus.app/Contents" at this point.
     wxFileName oSharedHome(m_sPrefix);
     oSharedHome.AppendDir("Resources");
-    oSharedHome.AppendDir(sVersion);
 #else
     // this is for Linux:
     wxFileName oSharedHome(m_sPrefix);

--- a/src/updater/lenmus_updater.cpp
+++ b/src/updater/lenmus_updater.cpp
@@ -251,6 +251,7 @@ may be down. Please, try again later.");
 //---------------------------------------------------------------------------------------
 bool Updater::CheckInternetConnection()
 {
+#ifndef __APPLE__
     bool fConnected = false;    //assume not connected
 
     // check connection
@@ -261,6 +262,9 @@ bool Updater::CheckInternetConnection()
 
     delete pManager;
     return fConnected;
+#else
+    return true;
+#endif
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
Modifications to CMakeList.txt are mostly from Cecilios, but I made a few changes as well.  None of the changes should interfere with compilation on Linux or Windows.  The Info.plist.in is also from Cecilios.  My changes to lenmus_app.cpp, lenmus_paths.cpp, and lenmus_updater.cpp are all delimited by suitable #if directives so that they should compile the same as before on Linux or Windows.  The change to lenmus_dlg_metronome.cpp was suggested by Cecilios -- I hope it doesn't affect anything.
macOS_build_instructions.txt is a detailed description of the build process on Macs -- tested on Catalina but should be the same on Mojave.

Main remaining TODO items:  (1) automate the process of adding support files to the MacOS app bundle (in CMakeList.txt?)   (2) figure out why it crashes on a few pages (almost certainly a case of a destructor being called prematurely -- if Xcode is told to enable Zombie objects it works just fine), and (3) figure out why the metronome toolbar doesn't look right.