### PR TITLE
Fix wxBitmapBundle issue #151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # LenMus Phonascus. Log of changes
 
 
-[Since last version] 6.0.0
+[Since last version] 6.0.1
 =============================
 
 * None
+
+
+Version [6.0.1] (Sep 23rd, 2022)
+==================================
+
+* Fixed compilation issue when building with wxWidgets >= 3.1.6
 
 
 Version [6.0.0] (Feb 12th, 2022)
@@ -714,8 +720,9 @@ Version 1.0 (Jan/2004):
 
 
 
-[Since last version]: https://github.com/lenmus/lenmus/compare/Release_6.0.0...HEAD
-[6.0.0]: https://github.com/lenmus/lenmus/compare/Release_5.6.1...Release_6.0.0
+[Since last version]: https://github.com/lenmus/lenmus/compare/Release_6.0.1...HEAD
+[6.0.1]: https://github.com/lenmus/lenmus/compare/Release_6.0.0...Release_6.0.1
+[6.0.0]: https://github.com/lenmus/lenmus/compare/Release_5.6.2...Release_6.0.0
 [5.6.2]: https://github.com/lenmus/lenmus/compare/Release_5.6.1...Release_5.6.2
 [5.6.1]: https://github.com/lenmus/lenmus/compare/Release_5.6.0...Release_5.6.1
 [5.6.0]: https://github.com/lenmus/lenmus/compare/Release_5.5.0...Release_5.6.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-lenmus (6.0.0) stable; urgency=low
+lenmus (6.0.1) stable; urgency=low
 
   * Latest release
 
- -- Cecilio Salmeron <s.cecilio@gmail.com>  Mon, 07 Feb 2022 12:24:33 +0100
+ -- Cecilio Salmeron <s.cecilio@gmail.com>  Fri, 23 Sep 2022 15:06:52 +0200
 

--- a/include/lenmus_content_box_ctrol.h
+++ b/include/lenmus_content_box_ctrol.h
@@ -129,7 +129,11 @@ public:
     wxWindow* GetHTMLWindow();
     wxColour GetHTMLBackgroundColour() const;
     void SetHTMLBackgroundColour(const wxColour& WXUNUSED(clr));
+#if wxCHECK_VERSION(3, 1, 6)
+    void SetHTMLBackgroundImage(const wxBitmapBundle& WXUNUSED(bmpBg));
+#else
     void SetHTMLBackgroundImage(const wxBitmap& WXUNUSED(bmpBg));
+#endif
     void SetHTMLStatusText(const wxString& WXUNUSED(text));
     wxCursor GetHTMLCursor(HTMLCursor type) const;
     wxPoint GetRootCellCoords(size_t n) const;

--- a/src/app/lenmus_content_box_ctrol.cpp
+++ b/src/app/lenmus_content_box_ctrol.cpp
@@ -989,7 +989,11 @@ void ContentBoxCtrol::SetHTMLBackgroundColour(const wxColour& WXUNUSED(clr))
     // nothing to do
 }
 
+#if wxCHECK_VERSION(3, 1, 6)
+void ContentBoxCtrol::SetHTMLBackgroundImage(const wxBitmapBundle& WXUNUSED(bmpBg))
+#else
 void ContentBoxCtrol::SetHTMLBackgroundImage(const wxBitmap& WXUNUSED(bmpBg))
+#endif
 {
     // nothing to do
 }

--- a/version-info.cmake
+++ b/version-info.cmake
@@ -29,7 +29,7 @@
 
 set( LENMUS_VERSION_MAJOR 6 )
 set( LENMUS_VERSION_MINOR 0 )
-set( LENMUS_VERSION_PATCH "0" )  #MUST BE string, e.g.: "3", "3-beta", "0"
+set( LENMUS_VERSION_PATCH "1" )  #MUST BE string, e.g.: "3", "3-beta", "0"
 
 # build version string for installer name
 set( LENMUS_PACKAGE_VERSION "${LENMUS_VERSION_MAJOR}.${LENMUS_VERSION_MINOR}.${LENMUS_VERSION_PATCH}" )


### PR DESCRIPTION
This PR fixes #151. It adds a conditional compilation change to use `wxBitmapBundle` when using `wxWidgets` >= 3.1.6; otherwise it will continue using `wxBitmap`.

wxWidgets version 3.1.6 replaced `wxBitmap` by `wxBitmapBundle` in all API methods . This backwards incompatible change affects LenMus code. `wxBitmapBundle` was introduced in 11/Feb/2022, commit 7a2a1e9074b70bfe1bb5527c2c54e3135b719959, and it was included in release 3.1.6

- 3.1.5 	14 April 2021 	
- 3.1.6 	4 April 2022 	
- 3.1.7 	6 June 2022 	
- 3.2.0 	7 July 2022 	
