### PR TITLE
Fix FindPortMidi: porttime is now included for Arch and Manjaro

### DIFF
--- a/cmake-modules/FindPortMidi.cmake
+++ b/cmake-modules/FindPortMidi.cmake
@@ -58,14 +58,14 @@ if (UNIX)
 
     #porttime is included in portmidi package
     set(DISTROS_NOT_USING_PORTTIME
+        Arch
         Fedora
+        ManjaroLinux
     )
     #porttime is an independent package
     set(DISTROS_USING_PORTTIME
-        Arch
         Debian
         LinuxMint
-        ManjaroLinux
         Ubuntu
     )
 


### PR DESCRIPTION
PortMidi has switched back to upstream and now porttime is part of portmidi.