### PR TITLE
Fix issues and warnings when using wxWidgets 3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,10 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
 endif()
 
+#disable pragma warning when compiling with GCC
+if ( CMAKE_COMPILER_IS_GNUCC )
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+endif()
 
 #------------------------------------------------------
 # macro STRING_UNQUOTE(var str)

--- a/include/lenmus_events.h
+++ b/include/lenmus_events.h
@@ -49,7 +49,9 @@ class DlgCounters;
 //      due to an auto-scroll while the score is being played back.
 //---------------------------------------------------------------------------------------
 
-DECLARE_EVENT_TYPE( lmEVT_UPDATE_VIEWPORT, -1 )
+//DECLARE_EVENT_TYPE( lmEVT_UPDATE_VIEWPORT, -1 )
+class lmUpdateViewportEvent;
+wxDECLARE_EVENT( lmEVT_UPDATE_VIEWPORT, lmUpdateViewportEvent );
 
 class lmUpdateViewportEvent : public wxEvent
 {
@@ -79,10 +81,10 @@ public:
 
 typedef void (wxEvtHandler::*UpdateViewportEventFunction)(lmUpdateViewportEvent&);
 
-#define LM_EVT_UPDATE_VIEWPORT(fn) \
-    DECLARE_EVENT_TABLE_ENTRY( lmEVT_UPDATE_VIEWPORT, wxID_ANY, -1, \
-    (wxObjectEventFunction) (wxEventFunction) (wxCommandEventFunction) (wxNotifyEventFunction) \
-    wxStaticCastEvent( UpdateViewportEventFunction, & fn ), (wxObject *) nullptr ),
+#define UpdateViewportEventHandler(func) wxEVENT_HANDLER_CAST(UpdateViewportEventFunction, func)
+
+#define LM_EVT_UPDATE_VIEWPORT(func) \
+ 	wx__DECLARE_EVT1( lmEVT_UPDATE_VIEWPORT, wxID_ANY, UpdateViewportEventHandler(func))
 
 
 //---------------------------------------------------------------------------------------
@@ -91,7 +93,9 @@ typedef void (wxEvtHandler::*UpdateViewportEventFunction)(lmUpdateViewportEvent&
 //      highlighting / unhighlighting notes while they are being played.
 //---------------------------------------------------------------------------------------
 
-DECLARE_EVENT_TYPE( lmEVT_SCORE_HIGHLIGHT, -1 )
+//DECLARE_EVENT_TYPE( lmEVT_SCORE_HIGHLIGHT, -1 )
+class lmVisualTrackingEvent;
+wxDECLARE_EVENT( lmEVT_SCORE_HIGHLIGHT, lmVisualTrackingEvent );
 
 class lmVisualTrackingEvent : public wxEvent
 {
@@ -121,17 +125,19 @@ public:
 
 typedef void (wxEvtHandler::*VisualTrackingEventFunction)(lmVisualTrackingEvent&);
 
-#define LM_EVT_SCORE_HIGHLIGHT(fn) \
-    DECLARE_EVENT_TABLE_ENTRY( lmEVT_SCORE_HIGHLIGHT, wxID_ANY, -1, \
-    (wxObjectEventFunction) (wxEventFunction) (wxCommandEventFunction) (wxNotifyEventFunction) \
-    wxStaticCastEvent( VisualTrackingEventFunction, & fn ), (wxObject *) nullptr ),
+#define VisualTrackingEventHandler(func) wxEVENT_HANDLER_CAST(VisualTrackingEventFunction, func)
+
+#define LM_EVT_SCORE_HIGHLIGHT(func) \
+ 	wx__DECLARE_EVT1( lmEVT_SCORE_HIGHLIGHT, wxID_ANY, VisualTrackingEventHandler(func))
 
 
 //---------------------------------------------------------------------------------------
 // lmEndOfPlaybackEvent: An event to signal end of playback
 //---------------------------------------------------------------------------------------
 
-DECLARE_EVENT_TYPE( lmEVT_END_OF_PLAYBACK, -1 )
+//DECLARE_EVENT_TYPE( lmEVT_END_OF_PLAYBACK, -1 )
+class lmEndOfPlaybackEvent;
+wxDECLARE_EVENT( lmEVT_END_OF_PLAYBACK, lmEndOfPlaybackEvent );
 
 class lmEndOfPlaybackEvent : public wxEvent
 {
@@ -161,10 +167,11 @@ public:
 
 typedef void (wxEvtHandler::*EndOfPlayEventFunction)(lmEndOfPlaybackEvent&);
 
-#define LM_EVT_END_OF_PLAYBACK(fn) \
-    DECLARE_EVENT_TABLE_ENTRY( lmEVT_END_OF_PLAYBACK, wxID_ANY, -1, \
-    (wxObjectEventFunction) (wxEventFunction) (wxCommandEventFunction) (wxNotifyEventFunction) \
-    wxStaticCastEvent( EndOfPlayEventFunction, & fn ), (wxObject *) nullptr ),
+#define EndOfPlayEventHandler(func) wxEVENT_HANDLER_CAST(EndOfPlayEventFunction, func)
+
+#define LM_EVT_END_OF_PLAYBACK(func) \
+ 	wx__DECLARE_EVT1( lmEVT_END_OF_PLAYBACK, wxID_ANY, EndOfPlayEventHandler(func))
+
 
 
 //---------------------------------------------------------------------------------------
@@ -172,7 +179,8 @@ typedef void (wxEvtHandler::*EndOfPlayEventFunction)(lmEndOfPlaybackEvent&);
 //      An event to signal different actions related to DlgCounters
 //---------------------------------------------------------------------------------------
 
-DECLARE_EVENT_TYPE( EVT_COUNTERS_DLG, -1 )
+class CountersEvent;
+wxDECLARE_EVENT( EVT_COUNTERS_DLG, CountersEvent );
 
 class CountersEvent : public wxEvent
 {
@@ -216,17 +224,18 @@ public:
 
 typedef void (wxEvtHandler::*CountersEventFunction)(CountersEvent&);
 
-#define LM_EVT_COUNTERS_DLG(fn) \
-    DECLARE_EVENT_TABLE_ENTRY( EVT_COUNTERS_DLG, wxID_ANY, -1, \
-    (wxObjectEventFunction) (wxEventFunction) (wxCommandEventFunction) (wxNotifyEventFunction) \
-    wxStaticCastEvent( CountersEventFunction, & fn ), (wxObject *) nullptr ),
+#define CountersEventHandler(func) wxEVENT_HANDLER_CAST(CountersEventFunction, func)
+
+#define LM_EVT_COUNTERS_DLG(func) \
+ 	wx__DECLARE_EVT1( EVT_COUNTERS_DLG, wxID_ANY, CountersEventHandler(func))
 
 
 //---------------------------------------------------------------------------------------
 // PageRequestEvent: An event for requesting to display an eBook page
 //---------------------------------------------------------------------------------------
 
-DECLARE_EVENT_TYPE( lmEVT_PAGE_REQUEST, -1 )
+class PageRequestEvent;
+wxDECLARE_EVENT( lmEVT_PAGE_REQUEST, PageRequestEvent );
 
 class PageRequestEvent : public wxEvent
 {
@@ -256,10 +265,10 @@ public:
 
 typedef void (wxEvtHandler::*PageRequestEventFunction)(PageRequestEvent&);
 
-#define LM_EVT_PAGE_REQUEST(fn) \
-    DECLARE_EVENT_TABLE_ENTRY( lmEVT_PAGE_REQUEST, wxID_ANY, -1, \
-    (wxObjectEventFunction) (wxEventFunction) (wxCommandEventFunction) (wxNotifyEventFunction) \
-    wxStaticCastEvent( PageRequestEventFunction, & fn ), (wxObject *) nullptr ),
+#define PageRequestEventHandler(func) wxEVENT_HANDLER_CAST(PageRequestEventFunction, func)
+
+#define LM_EVT_PAGE_REQUEST(func) \
+ 	wx__DECLARE_EVT1( lmEVT_PAGE_REQUEST, wxID_ANY, PageRequestEventHandler(func))
 
 
 }   // namespace lenmus

--- a/src/app/lenmus_app.cpp
+++ b/src/app/lenmus_app.cpp
@@ -376,10 +376,12 @@ wxString TheApp::determine_exec_path()
         strncpy(newpath2, saved_pwd, sizeof(newpath2));
         newpath2[sizeof(newpath2)-1]=0;
 
-        strncat(newpath2, path_separator_as_string, sizeof(newpath2));
+        size_t remaining = sizeof(newpath2) - strlen(newpath2) - 1;
+        strncat(newpath2, path_separator_as_string, remaining);
         newpath2[sizeof(newpath2)-1]=0;
 
-        strncat(newpath2, saved_argv0, sizeof(newpath2));
+        remaining = sizeof(newpath2) - strlen(newpath2) - 1;
+        strncat(newpath2, saved_argv0, remaining);
         newpath2[sizeof(newpath2)-1]=0;
 
         res = realpath(newpath2, newpath);
@@ -411,10 +413,12 @@ wxString TheApp::determine_exec_path()
             strncpy(newpath2, pathitem, sizeof(newpath2));
             newpath2[sizeof(newpath2)-1]=0;
 
-            strncat(newpath2, path_separator_as_string, sizeof(newpath2));
+            size_t remaining = sizeof(newpath2) - strlen(newpath2) - 1;
+            strncat(newpath2, path_separator_as_string, remaining);
             newpath2[sizeof(newpath2)-1]=0;
 
-            strncat(newpath2, saved_argv0, sizeof(newpath2));
+            remaining = sizeof(newpath2) - strlen(newpath2) - 1;
+            strncat(newpath2, saved_argv0, remaining);
             newpath2[sizeof(newpath2)-1]=0;
 
             res = realpath(newpath2, newpath);

--- a/src/app/lenmus_events.cpp
+++ b/src/app/lenmus_events.cpp
@@ -27,12 +27,19 @@
 namespace lenmus
 {
 
-DEFINE_EVENT_TYPE( lmEVT_UPDATE_VIEWPORT )
-DEFINE_EVENT_TYPE( lmEVT_SCORE_HIGHLIGHT )
-DEFINE_EVENT_TYPE( lmEVT_END_OF_PLAYBACK )
-DEFINE_EVENT_TYPE( lmEVT_MOVE_TEMPO_LINE )
-DEFINE_EVENT_TYPE( EVT_COUNTERS_DLG )
-DEFINE_EVENT_TYPE( lmEVT_PAGE_REQUEST )
+//DEFINE_EVENT_TYPE( lmEVT_MOVE_TEMPO_LINE )
+
+class lmUpdateViewportEvent;
+wxDEFINE_EVENT( lmEVT_UPDATE_VIEWPORT, lmUpdateViewportEvent );
+class lmVisualTrackingEvent;
+wxDEFINE_EVENT( lmEVT_SCORE_HIGHLIGHT, lmVisualTrackingEvent );
+class lmEndOfPlaybackEvent;
+wxDEFINE_EVENT( lmEVT_END_OF_PLAYBACK, lmEndOfPlaybackEvent );
+class CountersEvent;
+wxDEFINE_EVENT( EVT_COUNTERS_DLG, CountersEvent );
+class PageRequestEvent;
+wxDEFINE_EVENT( lmEVT_PAGE_REQUEST, PageRequestEvent);
+
 
 
 }   // namespace lenmus

--- a/src/app/lenmus_main_frame.cpp
+++ b/src/app/lenmus_main_frame.cpp
@@ -1154,6 +1154,7 @@ void MainFrame::get_font_filename(RequestFont* pRequest)
 #if (LENMUS_PLATFORM_UNIX == 1 || LENMUS_PLATFORM_MAC == 1)
 
     //method get_font_filename() is not invoked in Linux
+    do { (void)(pRequest); } while (0); //to avoid warning: unused parameter pRequest
 
 #elif (LENMUS_PLATFORM_WIN32 == 1)
 

--- a/src/exercises/ctrols/lenmus_exercise_ctrol.cpp
+++ b/src/exercises/ctrols/lenmus_exercise_ctrol.cpp
@@ -978,8 +978,7 @@ CompareScoresCtrol::CompareScoresCtrol(long dynId, ApplicationScope& appScope,
 {
     m_pScore[0] = nullptr;
     m_pScore[1] = nullptr;
-    Connect(wxID_ANY, wxEVT_TIMER,
-        (wxObjectEventFunction)(void (wxEvtHandler::*)(wxTimerEvent&))&CompareScoresCtrol::on_timer_event);
+    Bind(wxEVT_TIMER, &CompareScoresCtrol::on_timer_event, this);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/globals/lenmus_paths.cpp
+++ b/src/globals/lenmus_paths.cpp
@@ -201,7 +201,7 @@ void Paths::initialize()
     wxFileName oSoundFonts(m_sPrefix);
     oSoundFonts.AppendDir("res");
     oSoundFonts.AppendDir("sounds");
-    
+
 
 
 #elif (LENMUS_PLATFORM_UNIX == 1 || LENMUS_PLATFORM_MAC == 1)
@@ -226,7 +226,7 @@ void Paths::initialize()
     oSharedHome.AppendDir("lenmus");
     oSharedHome.AppendDir(sVersion);
 #endif
-    
+
     //Remaining configuration should be the same for Linux or Mac.
 
     //3. Configuration files, user & version dependent (CONFIG_DIR)
@@ -303,7 +303,7 @@ void Paths::initialize()
         oSoundFonts.AppendDir("res");
         oSoundFonts.AppendDir("sounds");
     }
-    oSoundFonts.Normalize();
+    oSoundFonts.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE );
 
 
 #elif (LENMUS_PLATFORM_WIN32 == 1)
@@ -460,7 +460,7 @@ void Paths::initialize()
 
     //Paths for tests and debug. Only valid in local debug builds
     path = wxFileName(LENMUS_SOURCE_ROOT);
-    path.Normalize();
+    path.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE );
     #if (LENMUS_PLATFORM_WIN32 == 1)
         //for replacing drive letter in Windows
         wxFileName drive(m_sBin);
@@ -469,7 +469,7 @@ void Paths::initialize()
     m_sSourceRoot = path.GetPath(wxPATH_GET_VOLUME | wxPATH_GET_SEPARATOR);
 
     path = wxFileName(LENMUS_TEST_SCORES_PATH);
-    path.Normalize();
+    path.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE );
     #if (LENMUS_PLATFORM_WIN32 == 1)
         path.SetVolume( drive.GetVolume() );
     #endif
@@ -516,7 +516,7 @@ void Paths::determine_prefix()
     oPrefix.AssignDir(m_sBin);
     oPrefix.RemoveLastDir();    // bin
 #endif
-    oPrefix.Normalize();
+    oPrefix.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE );
     m_sPrefix = oPrefix.GetPath(wxPATH_GET_VOLUME | wxPATH_GET_SEPARATOR);
 }
 


### PR DESCRIPTION
- Fix possible buffer overflow and warnings
- Fix wxWidgets backwards incompatible change with `wxFileName.Normalize()` method
- Fix warning with wxWidgets Connect method
- Fix warnings due to using old wxWidgets event macros
- Dissable unknown pragma warnings in GCC due to wxWidgets
