### PR TITLE
Bumping minimum cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@
 #
 #-------------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 message(STATUS "Using cmake version ${CMAKE_VERSION}")
 
 # project name


### PR DESCRIPTION
CMake v4.0 dropped support for versions older than 3.5: https://cmake.org/cmake/help/latest/release/4.0.html#id12

Version 3.5 was released in 2018, 6½ years ago: https://cmake.org/cmake/help/latest/release/4.0.html#id12

This is essentially the same solution as https://github.com/Grumbel/jstest-gtk/pull/29